### PR TITLE
Deploy VM without postfix number in VM's name and hostname

### DIFF
--- a/vsphere_virtual_machine_bare.tf
+++ b/vsphere_virtual_machine_bare.tf
@@ -1,6 +1,6 @@
 resource "vsphere_virtual_machine" "virtual_machine_bare" {
   count            = "${var.template_os_family == "" ? var.vm_count : 0}"
-  name             = "${var.vm_name_prefix}${count.index}"
+  name             = "${var.vm_name_prefix}-${var.vm_count == 1 ? "" : "${count.index}"}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.ds.id}"
 

--- a/vsphere_virtual_machine_linux.tf
+++ b/vsphere_virtual_machine_linux.tf
@@ -1,6 +1,6 @@
 resource "vsphere_virtual_machine" "virtual_machine_linux" {
   count            = "${var.template_os_family == "linux" ? var.vm_count : 0}"
-  name             = "${var.vm_name_prefix}${count.index}"
+  name             = "${var.vm_name_prefix}-${var.vm_count == 1 ? "" : "${count.index}"}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.ds.id}"
 
@@ -27,7 +27,7 @@ resource "vsphere_virtual_machine" "virtual_machine_linux" {
 
     customize {
       linux_options {
-        host_name = "${var.vm_name_prefix}${count.index}"
+        host_name = "${var.vm_name_prefix}-${var.vm_count == 1 ? "" : "${count.index}"}"
         domain    = "${var.domain_name}"
         time_zone = "${var.time_zone != "" ? var.time_zone : "UTC"}"
       }

--- a/vsphere_virtual_machine_windows.tf
+++ b/vsphere_virtual_machine_windows.tf
@@ -1,6 +1,6 @@
 resource "vsphere_virtual_machine" "virtual_machine_windows" {
   count            = "${var.template_os_family == "windows" ? var.vm_count : 0}"
-  name             = "${var.vm_name_prefix}${count.index}"
+  name             = "${var.vm_name_prefix}-${var.vm_count == 1 ? "" : "${count.index}"}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.ds.id}"
 
@@ -27,7 +27,7 @@ resource "vsphere_virtual_machine" "virtual_machine_windows" {
 
     customize {
       windows_options {
-        computer_name  = "${var.vm_name_prefix}${count.index}"
+        computer_name  = "${var.vm_name_prefix}-${var.vm_count == 1 ? "" : "${count.index}"}"
         admin_password = "${var.admin_password}"
         workgroup      = "${var.workgroup}"
         time_zone      = "${var.time_zone != "" ? var.time_zone : "85"}"


### PR DESCRIPTION
This will allow to create VM's hostname and name without postfix number when var.vm_count == 1.